### PR TITLE
Detect when permissions errors are thrown

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ef-discord-bot",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/src/commands/graph.js
+++ b/src/commands/graph.js
@@ -17,7 +17,7 @@ const sendGraphMessage = ({
     .setDescription(`Here's your recent progress on ${chartType} gain!`);
   message.channel.send(re).then(() => {
     chart.deleteChart(chartFilename);
-  });
+  }).catch(utils.handleSendMessageError(message));
 };
 
 const graphCommand = {

--- a/src/commands/raid.js
+++ b/src/commands/raid.js
@@ -138,7 +138,7 @@ const raidCommand = {
         raidGrade,
       });
 
-      message.channel.send(messageToSend);
+      message.channel.send(messageToSend).catch(utils.handleSendMessageError(message));
 
       datastore.saveRaidDamage({
         kl,

--- a/src/commands/record.js
+++ b/src/commands/record.js
@@ -280,7 +280,7 @@ const recordCommand = {
             description,
             assessment,
           );
-          message.channel.send(messageToSend);
+          message.channel.send(messageToSend).catch(utils.handleSendMessageError(message));
 
           datastore.saveProgress(kl, totalStr, rateStr, percentage, userId, username, timestamp);
         });
@@ -320,7 +320,7 @@ const gradeCommand = {
             percentage,
           );
 
-          message.channel.send(messageToSend);
+          message.channel.send(messageToSend).catch(utils.handleSendMessageError(message));
         });
     });
   },

--- a/src/utils.js
+++ b/src/utils.js
@@ -329,3 +329,21 @@ export const getMSUntilReset = (now) => {
 
   return midnightUTC - now;
 };
+
+export const handleSendMessageError = message => (error) => {
+  if (error.name === 'DiscordAPIError' && error.message === 'Missing Permissions') {
+    const channelName = _.get(message, 'channel.name');
+    const guildName = _.get(message, 'channel.guild.name');
+    console.error(`Permissions error when trying to send a message to #${channelName} on server: ${guildName}`);
+
+    // Try to send a distress beacon to the channel to help inform their admins to
+    // adjust the permissions of the bot
+    message.channel.send('I do not have the appropriate permissions to send the message I was going to send. Please confirm I have the right permissions! (I need to be able to send messages, embed links, and attach files)')
+      .catch(() => {
+        // Don't bother doing anything
+        // the bot doesn't even have permissions to send a text message!
+      });
+  } else {
+    console.error('Unexpected error encountered when trying to send a message', error);
+  }
+};


### PR DESCRIPTION
If the bot doesn't have permission to send embeds or attach files, it will throw an unhandled promise rejection. This catches those, and provides logging to indicate where the permissions issue is